### PR TITLE
Improve HTTP/2 and HTTP/3 framing and minimal header decoding

### DIFF
--- a/src/net/http/http2.c
+++ b/src/net/http/http2.c
@@ -29,6 +29,15 @@
 #define CWIST_HTTP2_MAX_FRAME_SIZE 16384
 #define CWIST_HTTP2_MAX_CONCURRENT_STREAMS 32
 
+#define CWIST_HTTP2_FLAG_END_STREAM 0x01
+#define CWIST_HTTP2_FLAG_END_HEADERS 0x04
+#define CWIST_HTTP2_FLAG_PADDED 0x08
+#define CWIST_HTTP2_FLAG_PRIORITY 0x20
+#define CWIST_HTTP2_FLAG_ACK 0x01
+#define CWIST_HTTP2_FRAME_DATA 0x00
+#define CWIST_HTTP2_FRAME_HEADERS 0x01
+#define CWIST_HTTP2_FRAME_SETTINGS 0x04
+
 /**
  * @brief Internal state for an HTTP/2 connection.
  *
@@ -43,6 +52,53 @@ typedef struct {
 
 /* --- Private Function Prototypes --- */
 
+typedef struct {
+    const char *name;
+    const char *value;
+} cwist_http2_static_header;
+
+static const cwist_http2_static_header cwist_http2_static_table[] = {
+    { NULL, NULL },
+    { ":authority", "" },
+    { ":method", "GET" },
+    { ":method", "POST" },
+    { ":path", "/" },
+    { ":path", "/index.html" },
+    { ":scheme", "http" },
+    { ":scheme", "https" },
+    { ":status", "200" },
+    { ":status", "204" },
+    { ":status", "206" },
+    { ":status", "304" },
+    { ":status", "400" },
+    { ":status", "404" },
+    { ":status", "500" },
+    { "accept-charset", "" },
+    { "accept-encoding", "gzip, deflate" },
+    { "accept-language", "" },
+    { "accept-ranges", "" },
+    { "accept", "" },
+    { "access-control-allow-origin", "" },
+    { "age", "" },
+    { "allow", "" },
+    { "authorization", "" },
+    { "cache-control", "" },
+    { "content-disposition", "" },
+    { "content-encoding", "" },
+    { "content-language", "" },
+    { "content-length", "" },
+    { "content-location", "" },
+    { "content-range", "" },
+    { "content-type", "" },
+    { "cookie", "" },
+    { "date", "" },
+    { "etag", "" },
+    { "expect", "" },
+    { "expires", "" },
+    { "from", "" },
+    { "host", "" },
+};
+
 static int h2_read(cwist_https_connection *conn, void *buf, int len) {
     if (conn->ssl) return SSL_read(conn->ssl, buf, len);
     return read(conn->fd, buf, len);
@@ -51,6 +107,182 @@ static int h2_read(cwist_https_connection *conn, void *buf, int len) {
 static int h2_write(cwist_https_connection *conn, const void *buf, int len) {
     if (conn->ssl) return SSL_write(conn->ssl, buf, len);
     return write(conn->fd, buf, len);
+}
+
+static int h2_write_all(cwist_https_connection *conn, const void *buf, size_t len) {
+    const unsigned char *p = (const unsigned char *)buf;
+    while (len > 0) {
+        int n = h2_write(conn, p, (int)len);
+        if (n <= 0) return -1;
+        p += n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+
+static void h2_make_frame_header(unsigned char out[CWIST_HTTP2_FRAME_HEADER_SIZE],
+                                 uint32_t len,
+                                 uint8_t type,
+                                 uint8_t flags,
+                                 uint32_t stream_id) {
+    out[0] = (unsigned char)((len >> 16) & 0xff);
+    out[1] = (unsigned char)((len >> 8) & 0xff);
+    out[2] = (unsigned char)(len & 0xff);
+    out[3] = type;
+    out[4] = flags;
+    out[5] = (unsigned char)((stream_id >> 24) & 0x7f);
+    out[6] = (unsigned char)((stream_id >> 16) & 0xff);
+    out[7] = (unsigned char)((stream_id >> 8) & 0xff);
+    out[8] = (unsigned char)(stream_id & 0xff);
+}
+
+static int h2_write_frame(cwist_https_connection *conn,
+                          uint8_t type,
+                          uint8_t flags,
+                          uint32_t stream_id,
+                          const unsigned char *payload,
+                          uint32_t len) {
+    unsigned char frame[CWIST_HTTP2_FRAME_HEADER_SIZE];
+    h2_make_frame_header(frame, len, type, flags, stream_id);
+    if (h2_write_all(conn, frame, sizeof(frame)) != 0) return -1;
+    if (len > 0 && payload) return h2_write_all(conn, payload, len);
+    return 0;
+}
+
+static int h2_decode_integer(const unsigned char *buf,
+                             size_t len,
+                             size_t *pos,
+                             uint8_t prefix_bits,
+                             uint32_t *value) {
+    if (*pos >= len || prefix_bits == 0 || prefix_bits > 8) return -1;
+    uint8_t mask = (uint8_t)((1u << prefix_bits) - 1u);
+    uint32_t n = buf[*pos] & mask;
+    (*pos)++;
+    if (n < mask) {
+        *value = n;
+        return 0;
+    }
+
+    uint32_t m = 0;
+    while (*pos < len) {
+        uint8_t b = buf[(*pos)++];
+        if (m > 28) return -1;
+        n += (uint32_t)(b & 0x7f) << m;
+        if ((b & 0x80) == 0) {
+            *value = n;
+            return 0;
+        }
+        m += 7;
+    }
+    return -1;
+}
+
+static char *h2_decode_string(const unsigned char *buf, size_t len, size_t *pos) {
+    if (*pos >= len) return NULL;
+    bool huffman = (buf[*pos] & 0x80) != 0;
+    uint32_t str_len = 0;
+    if (h2_decode_integer(buf, len, pos, 7, &str_len) != 0) return NULL;
+    if (huffman || *pos + str_len > len) return NULL;
+
+    char *out = (char *)malloc((size_t)str_len + 1);
+    if (!out) return NULL;
+    memcpy(out, buf + *pos, str_len);
+    out[str_len] = '\0';
+    *pos += str_len;
+    return out;
+}
+
+static const cwist_http2_static_header *h2_static_header(uint32_t index) {
+    size_t count = sizeof(cwist_http2_static_table) / sizeof(cwist_http2_static_table[0]);
+    if (index == 0 || index >= count) return NULL;
+    return &cwist_http2_static_table[index];
+}
+
+static void h2_apply_header(cwist_http_request *req, const char *name, const char *value) {
+    if (!req || !name || !value) return;
+
+    if (strcmp(name, ":method") == 0) {
+        req->method = cwist_http_string_to_method(value);
+    } else if (strcmp(name, ":path") == 0) {
+        cwist_sstring_assign(req->path, (char *)value);
+    } else if (strcmp(name, ":authority") == 0 || strcmp(name, "host") == 0) {
+        cwist_http_header_add(&req->headers, "Host", value);
+    } else if (strcmp(name, ":scheme") != 0 && name[0] != ':') {
+        cwist_http_header_add(&req->headers, name, value);
+    }
+}
+
+static void h2_decode_header_block(cwist_http_request *req, const unsigned char *payload, size_t len) {
+    size_t pos = 0;
+
+    while (pos < len) {
+        uint8_t b = payload[pos];
+        uint32_t name_index = 0;
+        char *name = NULL;
+        char *value = NULL;
+
+        if (b & 0x80) {
+            uint32_t index = 0;
+            if (h2_decode_integer(payload, len, &pos, 7, &index) != 0) break;
+            const cwist_http2_static_header *entry = h2_static_header(index);
+            if (entry && entry->name) h2_apply_header(req, entry->name, entry->value);
+            continue;
+        }
+
+        if ((b & 0x40) == 0x40) {
+            if (h2_decode_integer(payload, len, &pos, 6, &name_index) != 0) break;
+        } else if ((b & 0xf0) == 0x00) {
+            if (h2_decode_integer(payload, len, &pos, 4, &name_index) != 0) break;
+        } else if ((b & 0xf0) == 0x10) {
+            if (h2_decode_integer(payload, len, &pos, 4, &name_index) != 0) break;
+        } else {
+            break;
+        }
+
+        if (name_index > 0) {
+            const cwist_http2_static_header *entry = h2_static_header(name_index);
+            if (!entry || !entry->name) break;
+            name = strdup(entry->name);
+        } else {
+            name = h2_decode_string(payload, len, &pos);
+        }
+        value = h2_decode_string(payload, len, &pos);
+        if (!name || !value) {
+            free(name);
+            free(value);
+            break;
+        }
+        h2_apply_header(req, name, value);
+        free(name);
+        free(value);
+    }
+}
+
+static int h2_send_response(cwist_https_connection *conn, uint32_t stream_id, cwist_http_response *res) {
+    unsigned char status_200[] = { 0x88 };
+    size_t body_len = res->body ? res->body->size : 0;
+    const char *body_data = res->body ? res->body->data : "";
+    uint8_t header_flags = CWIST_HTTP2_FLAG_END_HEADERS;
+    if (body_len == 0) header_flags |= CWIST_HTTP2_FLAG_END_STREAM;
+
+    if (h2_write_frame(conn, CWIST_HTTP2_FRAME_HEADERS, header_flags, stream_id,
+                       status_200, sizeof(status_200)) != 0) {
+        return -1;
+    }
+
+    size_t sent = 0;
+    while (sent < body_len) {
+        size_t remaining = body_len - sent;
+        uint32_t chunk = (uint32_t)(remaining > CWIST_HTTP2_MAX_FRAME_SIZE ?
+                                   CWIST_HTTP2_MAX_FRAME_SIZE : remaining);
+        uint8_t flags = (sent + chunk == body_len) ? CWIST_HTTP2_FLAG_END_STREAM : 0;
+        if (h2_write_frame(conn, CWIST_HTTP2_FRAME_DATA, flags, stream_id,
+                           (const unsigned char *)body_data + sent, chunk) != 0) {
+            return -1;
+        }
+        sent += chunk;
+    }
+    return 0;
 }
 
 /**
@@ -108,6 +340,12 @@ cwist_error_t cwist_http2_serve_connection(
         return result;
     }
 
+    if (h2_write_frame(conn, CWIST_HTTP2_FRAME_SETTINGS, 0, 0, NULL, 0) != 0) {
+        result = make_error(CWIST_ERR_INT16);
+        result.error.err_i16 = -1;
+        return result;
+    }
+
     /* 3. Main Event Loop */
     bool connected = true;
     while (connected) {
@@ -126,6 +364,11 @@ cwist_error_t cwist_http2_serve_connection(
         uint8_t type = hdr[3];
         uint32_t stream_id = (((uint32_t)hdr[5] & 0x7f) << 24) | ((uint32_t)hdr[6] << 16) | ((uint32_t)hdr[7] << 8) | hdr[8];
 
+        if (len > CWIST_HTTP2_MAX_FRAME_SIZE) {
+            connected = false;
+            break;
+        }
+
         unsigned char *payload = NULL;
         if (len > 0) {
             payload = malloc(len);
@@ -138,54 +381,38 @@ cwist_error_t cwist_http2_serve_connection(
         }
         if (!connected) { free(payload); break; }
 
-        // Handle HEADERS frame minimally for the test requirements
-        if (type == 0x01) { 
+        if (type == CWIST_HTTP2_FRAME_SETTINGS) {
+            if ((hdr[4] & CWIST_HTTP2_FLAG_ACK) == 0) {
+                h2_write_frame(conn, CWIST_HTTP2_FRAME_SETTINGS, CWIST_HTTP2_FLAG_ACK, 0, NULL, 0);
+            }
+        } else if (type == CWIST_HTTP2_FRAME_HEADERS && stream_id != 0) {
             cwist_http_request *req = cwist_http_request_create();
+            if (!req) { free(payload); break; }
             cwist_sstring_assign(req->version, "HTTP/2");
 
-            if (len >= 3 && payload[0] == 0x82 && payload[1] == 0x87 && payload[2] == 0x84) {
-                cwist_sstring_assign(req->path, "/");
-            } else if (len >= 8 && payload[0] == 0x82 && payload[1] == 0x87 && payload[2] == 0x04) {
-                int path_len = payload[3];
-                char *path = malloc(path_len + 1);
-                memcpy(path, payload + 4, path_len);
-                path[path_len] = '\0';
-                cwist_sstring_assign(req->path, path);
-                free(path);
-            } else {
-                cwist_sstring_assign(req->path, "/"); // Fallback
+            size_t block_offset = 0;
+            size_t block_len = len;
+            if ((hdr[4] & CWIST_HTTP2_FLAG_PADDED) != 0 && block_len > 0) {
+                uint8_t pad_len = payload[block_offset++];
+                block_len--;
+                if (pad_len <= block_len) block_len -= pad_len;
+            }
+            if ((hdr[4] & CWIST_HTTP2_FLAG_PRIORITY) != 0 && block_len >= 5) {
+                block_offset += 5;
+                block_len -= 5;
+            }
+            if (payload && block_offset <= len) {
+                h2_decode_header_block(req, payload + block_offset, block_len);
             }
 
             cwist_http_response *res = cwist_http_response_create();
-            handler(user_ctx, req, res);
-
-            // Send HEADERS Frame (End Headers flag = 0x04)
-            unsigned char h_frame[9] = {0, 0, 1, 0x01, 0x04, (stream_id>>24)&0xff, (stream_id>>16)&0xff, (stream_id>>8)&0xff, stream_id&0xff};
-            unsigned char h_payload[1] = {0x88}; // HPACK :status 200
-            h2_write(conn, h_frame, 9);
-            h2_write(conn, h_payload, 1);
-
-            // Send DATA Frame
-            size_t body_len = res->body ? res->body->size : 0;
-            const char *body_data = res->body ? res->body->data : "";
-            size_t sent = 0;
-
-            if (body_len == 0) {
-                unsigned char d_frame[9] = {0, 0, 0, 0x00, 0x01, (stream_id>>24)&0xff, (stream_id>>16)&0xff, (stream_id>>8)&0xff, stream_id&0xff};
-                h2_write(conn, d_frame, 9);
-            } else {
-                while (sent < body_len) {
-                    size_t chunk = body_len - sent > 16384 ? 16384 : body_len - sent;
-                    unsigned char flags = (sent + chunk == body_len) ? 0x01 : 0x00; // End Stream flag
-                    unsigned char d_frame[9] = { (chunk>>16)&0xff, (chunk>>8)&0xff, chunk&0xff, 0x00, flags, (stream_id>>24)&0xff, (stream_id>>16)&0xff, (stream_id>>8)&0xff, stream_id&0xff};
-                    h2_write(conn, d_frame, 9);
-                    h2_write(conn, body_data + sent, chunk);
-                    sent += chunk;
-                }
+            if (res) {
+                handler(user_ctx, req, res);
+                if (h2_send_response(conn, stream_id, res) != 0) connected = false;
+                cwist_http_response_destroy(res);
             }
 
             cwist_http_request_destroy(req);
-            cwist_http_response_destroy(res);
         }
 
         free(payload);

--- a/src/net/http/http3.c
+++ b/src/net/http/http3.c
@@ -156,6 +156,120 @@ void cwist_http3_destroy_context(cwist_http3_context *ctx) {
     }
 }
 
+
+#define CWIST_HTTP3_FRAME_DATA 0x00
+#define CWIST_HTTP3_FRAME_HEADERS 0x01
+
+static size_t h3_encode_varint(uint64_t value, unsigned char out[8]) {
+    if (value <= 0x3f) {
+        out[0] = (unsigned char)value;
+        return 1;
+    }
+    if (value <= 0x3fff) {
+        out[0] = (unsigned char)(0x40 | ((value >> 8) & 0x3f));
+        out[1] = (unsigned char)(value & 0xff);
+        return 2;
+    }
+    if (value <= 0x3fffffff) {
+        out[0] = (unsigned char)(0x80 | ((value >> 24) & 0x3f));
+        out[1] = (unsigned char)((value >> 16) & 0xff);
+        out[2] = (unsigned char)((value >> 8) & 0xff);
+        out[3] = (unsigned char)(value & 0xff);
+        return 4;
+    }
+    out[0] = (unsigned char)(0xc0 | ((value >> 56) & 0x3f));
+    out[1] = (unsigned char)((value >> 48) & 0xff);
+    out[2] = (unsigned char)((value >> 40) & 0xff);
+    out[3] = (unsigned char)((value >> 32) & 0xff);
+    out[4] = (unsigned char)((value >> 24) & 0xff);
+    out[5] = (unsigned char)((value >> 16) & 0xff);
+    out[6] = (unsigned char)((value >> 8) & 0xff);
+    out[7] = (unsigned char)(value & 0xff);
+    return 8;
+}
+
+static int h3_decode_varint(const unsigned char *buf, size_t len, size_t *pos, uint64_t *value) {
+    if (*pos >= len) return -1;
+    unsigned char first = buf[*pos];
+    size_t width = (size_t)1u << (first >> 6);
+    if (*pos + width > len) return -1;
+
+    uint64_t v = (uint64_t)(first & 0x3f);
+    for (size_t i = 1; i < width; i++) {
+        v = (v << 8) | buf[*pos + i];
+    }
+    *pos += width;
+    *value = v;
+    return 0;
+}
+
+static int h3_ssl_write_all(SSL *stream, const void *buf, size_t len) {
+    const unsigned char *p = (const unsigned char *)buf;
+    while (len > 0) {
+        int n = SSL_write(stream, p, len);
+        if (n <= 0) return -1;
+        p += n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+
+static int h3_write_frame(SSL *stream, uint64_t type, const unsigned char *payload, size_t payload_len) {
+    unsigned char header[16];
+    unsigned char encoded[8];
+    size_t header_len = 0;
+
+    size_t n = h3_encode_varint(type, encoded);
+    memcpy(header + header_len, encoded, n);
+    header_len += n;
+    n = h3_encode_varint(payload_len, encoded);
+    memcpy(header + header_len, encoded, n);
+    header_len += n;
+
+    if (h3_ssl_write_all(stream, header, header_len) != 0) return -1;
+    if (payload_len > 0 && payload) return h3_ssl_write_all(stream, payload, payload_len);
+    return 0;
+}
+
+static void h3_apply_minimal_request_headers(cwist_http_request *req,
+                                             const unsigned char *buf,
+                                             size_t len) {
+    size_t pos = 0;
+    while (pos < len) {
+        uint64_t type = 0;
+        uint64_t frame_len = 0;
+        if (h3_decode_varint(buf, len, &pos, &type) != 0 ||
+            h3_decode_varint(buf, len, &pos, &frame_len) != 0 ||
+            pos + frame_len > len) {
+            break;
+        }
+
+        if (type == CWIST_HTTP3_FRAME_HEADERS && frame_len >= 3) {
+            const unsigned char *block = buf + pos;
+            /* Minimal QPACK awareness: skip required-insert-count and delta-base.
+             * Full request decoding is intentionally left to a future QPACK table implementation. */
+            if (block[0] == 0x00 && block[1] == 0x00) {
+                req->method = CWIST_HTTP_GET;
+            }
+        }
+        pos += frame_len;
+    }
+}
+
+static int h3_send_response(SSL *stream, cwist_http_response *res) {
+    /* QPACK header block: required insert count = 0, delta base = 0,
+     * indexed static field line :status 200. */
+    static const unsigned char headers_200[] = { 0x00, 0x00, 0xd9 };
+    size_t body_len = res->body ? res->body->size : 0;
+    const char *body_data = res->body ? res->body->data : "";
+
+    if (h3_write_frame(stream, CWIST_HTTP3_FRAME_HEADERS, headers_200, sizeof(headers_200)) != 0) {
+        return -1;
+    }
+    return h3_write_frame(stream, CWIST_HTTP3_FRAME_DATA,
+                          (const unsigned char *)body_data, body_len);
+}
+
 /**
  * @brief Handle an individual QUIC stream.
  *
@@ -167,55 +281,49 @@ void cwist_http3_destroy_context(cwist_http3_context *ctx) {
  * @param user_ctx Opaque pointer.
  */
 static void cwist_http3_handle_stream(SSL *stream, cwist_http3_request_handler_func handler, void *user_ctx) {
-    bool connected = true;
-    while (connected) {
-        /* HTTP/3 frames consist of a Variable-Length Integer for Type and Length */
-        /* For this standard structural skeleton, we mock reading a basic frame to fulfill stream lifecycle */
-        unsigned char buf[1024];
-        int n = SSL_read(stream, buf, sizeof(buf));
-        if (n <= 0) {
-            int ssl_err = SSL_get_error(stream, n);
-            if (ssl_err == SSL_ERROR_WANT_READ || ssl_err == SSL_ERROR_WANT_WRITE) {
-                /* In a fully non-blocking implementation, we'd return to the poll loop.
-                 * For standard multi-threaded or blocking stream handle, we'd sleep or poll. */
-                usleep(1000);
-                continue;
-            }
-            break; /* Stream closed or error */
+    unsigned char buf[4096];
+    size_t buffered = 0;
+
+    while (buffered < sizeof(buf)) {
+        int n = SSL_read(stream, buf + buffered, sizeof(buf) - buffered);
+        if (n > 0) {
+            buffered += (size_t)n;
+            break;
         }
 
-        /* 
-         * Typical HTTP/3 QPACK and framing parsing happens here.
-         * Since OpenSSL provides transport, we extract the path from the QPACK block.
-         */
-        
-        cwist_http_request *req = cwist_http_request_create();
-        cwist_sstring_assign(req->version, "HTTP/3");
-        cwist_sstring_assign(req->path, "/"); /* Default fallback */
-
-        cwist_http_response *res = cwist_http_response_create();
-        
-        if (handler) {
-            handler(user_ctx, req, res);
+        int ssl_err = SSL_get_error(stream, n);
+        if (ssl_err == SSL_ERROR_WANT_READ || ssl_err == SSL_ERROR_WANT_WRITE) {
+            usleep(1000);
+            continue;
         }
-
-        /* Encode HTTP/3 Headers and Data frames.
-         * We write a minimal static response block for now to satisfy stream lifecycle.
-         */
-        size_t body_len = res->body ? res->body->size : 0;
-        const char *body_data = res->body ? res->body->data : "";
-        
-        if (body_len > 0) {
-            /* Very basic simulated frame header write */
-            SSL_write(stream, body_data, body_len);
+        if (ssl_err == SSL_ERROR_ZERO_RETURN) {
+            break;
         }
+        break;
+    }
 
+    cwist_http_request *req = cwist_http_request_create();
+    cwist_http_response *res = cwist_http_response_create();
+    if (!req || !res) {
         cwist_http_request_destroy(req);
         cwist_http_response_destroy(res);
-        break; /* Single request per unidirectional/bidirectional stream standard in HTTP/3 */
+        SSL_free(stream);
+        return;
     }
-    
-    /* Conclude stream */
+
+    cwist_sstring_assign(req->version, "HTTP/3");
+    cwist_sstring_assign(req->path, "/");
+    h3_apply_minimal_request_headers(req, buf, buffered);
+
+    if (handler) {
+        handler(user_ctx, req, res);
+    }
+
+    h3_send_response(stream, res);
+    SSL_stream_conclude(stream, 0);
+
+    cwist_http_request_destroy(req);
+    cwist_http_response_destroy(res);
     SSL_free(stream);
 }
 


### PR DESCRIPTION
### Motivation

- The existing HTTP/2 code used hardcoded byte-pattern checks and the HTTP/3 code sent body bytes without protocol framing, which caused interoperability failures with real clients; the handlers need minimal HPACK/QPACK awareness and correct frame assembly to follow protocol framing rules.

### Description

- Add HTTP/2 framing helpers and writers in `src/net/http/http2.c` (`h2_make_frame_header`, `h2_write_frame`, `h2_write_all`) and send an initial SETTINGS frame and SETTINGS ACK handling. 
- Implement a minimal HPACK static table and header block decoder (`h2_decode_integer`, `h2_decode_string`, `h2_decode_header_block`, `h2_apply_header`) and handle `PADDED`/`PRIORITY` flags so pseudo-headers (`:method`, `:path`, `:authority`) and `Host` are applied to the request object; responses are emitted via `h2_send_response` which writes HEADERS then DATA frames with correct `END_HEADERS`/`END_STREAM` flags. 
- Add HTTP/3 variable-length integer helpers and a frame writer in `src/net/http/http3.c` (`h3_encode_varint`, `h3_decode_varint`, `h3_write_frame`, `h3_ssl_write_all`), a minimal QPACK-style `:status 200` header block, and `h3_send_response` to send HEADERS then DATA; request handling now sets `req->version` to "HTTP/3" and applies minimal header extraction. 
- Make small safety and bounds checks (max frame size checks, null checks) and attempt to conclude QUIC streams using `SSL_stream_conclude` after sending responses.

### Testing

- Ran `git diff --check` to validate the diff formatting and found no issues. 
- Performed syntax-only compilation checks with `cc -fsyntax-only` on `src/net/http/http2.c` and `src/net/http/http3.c`, which passed. 
- Attempted full project build (`make -j2`) but the complete build failed because vendored submodules / source files (`lib/libttak` Makefile target and `lib/cjson/cJSON.c`) are missing in this checkout. 
- Attempted to install missing system packages but `apt-get` was blocked by the environment (HTTP 403 from configured proxy), so end-to-end integration tests could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c959e780833080de2cbadada46f6)