### PR TITLE
Makefile: run full test suite with `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,37 @@ $(URIPARSER_LIB):
 
 # --- Test Targets ---
 
-test: $(LIB_NAME) tests/test_sstring.c
+TEST_TARGETS = test_sstring \
+               test_http \
+               test_siphash \
+               test_mux \
+               test_mux_param \
+               stress_test \
+               test_cors \
+               test_websocket \
+               test_jwt \
+               test_migrate \
+               test_json_heal \
+               test_https \
+               test_http2 \
+               test_http3 \
+               nuke_missing_user_test
+
+.PHONY: all test $(TEST_TARGETS) install uninstall clean rebuild
+
+test: $(TEST_TARGETS)
+
+test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)
 	./test_sstring
+
+test_http: $(LIB_NAME) tests/test_http.c
+	$(CC) $(CFLAGS) -o test_http tests/test_http.c $(LIB_NAME) $(LIBS)
+	./test_http
+
+test_siphash: $(LIB_NAME) tests/test_siphash.c
+	$(CC) $(CFLAGS) -o test_siphash tests/test_siphash.c $(LIB_NAME) $(LIBS)
+	./test_siphash
 
 test_mux: $(LIB_NAME) tests/test_mux.c
 	$(CC) $(CFLAGS) -o test_mux tests/test_mux.c $(LIB_NAME) $(LIBS)
@@ -187,7 +215,21 @@ test_http3: $(LIB_NAME) tests/test_http3.c
 	$(CC) $(CFLAGS) -o test_http3 tests/test_http3.c $(LIB_NAME) $(LIBS)
 	./test_http3
 
-# ... (other tests omitted for brevity, keeping standard ones)
+stress_test: $(LIB_NAME) tests/stress_test.c
+	$(CC) $(CFLAGS) -o stress_test tests/stress_test.c $(LIB_NAME) $(LIBS)
+	./stress_test
+
+test_cors: $(LIB_NAME) tests/test_cors.c
+	$(CC) $(CFLAGS) -o test_cors tests/test_cors.c $(LIB_NAME) $(LIBS)
+	./test_cors
+
+test_websocket: $(LIB_NAME) tests/test_websocket.c
+	$(CC) $(CFLAGS) -o test_websocket tests/test_websocket.c $(LIB_NAME) $(LIBS)
+	./test_websocket
+
+nuke_missing_user_test: $(LIB_NAME) tests/nuke_missing_user_test.c
+	$(CC) $(CFLAGS) -o nuke_missing_user_test tests/nuke_missing_user_test.c $(LIB_NAME) $(LIBS)
+	./nuke_missing_user_test
 
 install: $(LIB_NAME)
 	@echo "Installing library to $(LIBDIR)..."
@@ -215,9 +257,7 @@ clean:
 	@echo "Cleaning up build artifacts..."
 	rm -f $(OBJS) $(LIB_NAME)
 	rm -rf include/cwist/vendor
-	rm -f test_sstring test_http test_siphash test_mux stress_test test_cors test_websocket test_jwt test_migrate test_json_heal
-	rm -f test_https
-	rm -f test_http2
+	rm -f $(TEST_TARGETS)
 	rm -f $(CJSON_DIR)/cJSON.o $(CJSON_LIB)
 	rm -rf $(URIPARSER_BUILD_DIR)
 	@$(MAKE) -C $(LIBTTAK_DIR) clean


### PR DESCRIPTION
### Motivation

- Ensure `make test` executes the full set of C test binaries instead of only `test_sstring` so repository-level CI/local runs exercise all tests.
- Simplify test maintenance by consolidating test targets and cleanup into a single list for consistency.

### Description

- Add a `TEST_TARGETS` variable listing all test targets and make `test` depend on `$(TEST_TARGETS)`. 
- Add missing individual test targets such as `test_http`, `test_siphash`, `stress_test`, `test_cors`, `test_websocket`, and `nuke_missing_user_test` so each test can be run independently. 
- Declare test-related targets as `.PHONY` and change `clean` to remove `$(TEST_TARGETS)` instead of hardcoding individual binaries. 
- Keep existing per-test build/invoke rules but wire them into the central `TEST_TARGETS` list for `make test` orchestration.

### Testing

- Ran `make -n test` which printed the expanded build and test invocation steps for all targets as expected. 
- Ran `make test` which reached the uriparser configuration step and failed because the `lib/uriparser` directory in-tree does not contain `CMakeLists.txt`, so the full test execution was blocked by the missing submodule contents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e99dec908330868ffef947c0a7fc)